### PR TITLE
Fix all GetThemeMargins API calls which may return invalid values for the pMargins parameter.

### DIFF
--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -184,10 +184,6 @@ private:
 
 #if wxUSE_UXTHEME
 
-// somehow the margin is one pixel greater than the value returned by
-// GetThemeMargins() call
-const int XP_BUTTON_EXTRA_MARGIN = 1;
-
 class wxXPButtonImageData : public wxButtonImageData
 {
 public:
@@ -525,22 +521,18 @@ void wxAnyButton::AdjustForBitmapSize(wxSize &size) const
             wxUxThemeHandle theme(const_cast<wxAnyButton *>(this), L"BUTTON");
 
             MARGINS margins;
-            ::GetThemeMargins(theme, NULL,
-                                                    BP_PUSHBUTTON,
-                                                    PBS_NORMAL,
-                                                    TMT_CONTENTMARGINS,
-                                                    NULL,
-                                                    &margins);
+            if (::GetThemeMargins(theme, NULL, BP_PUSHBUTTON, PBS_NORMAL,
+                                  TMT_CONTENTMARGINS, NULL,
+                                  &margins) != S_OK)
+                wxZeroMemory(margins);
 
             // XP doesn't draw themed buttons correctly when the client
             // area is smaller than 8x8 - enforce this minimum size for
             // small bitmaps
             size.IncTo(wxSize(8, 8));
 
-            marginH = margins.cxLeftWidth + margins.cxRightWidth
-                        + 2*XP_BUTTON_EXTRA_MARGIN;
-            marginV = margins.cyTopHeight + margins.cyBottomHeight
-                        + 2*XP_BUTTON_EXTRA_MARGIN;
+            marginH = margins.cxLeftWidth + margins.cxRightWidth;
+            marginV = margins.cyTopHeight + margins.cyBottomHeight;
         }
         else
 #endif // wxUSE_UXTHEME
@@ -1150,10 +1142,12 @@ void DrawXPBackground(wxAnyButton *button, HDC hdc, RECT& rectBtn, UINT state)
 
     // calculate content area margins
     MARGINS margins;
-    ::GetThemeMargins(theme, hdc, BP_PUSHBUTTON, iState,
-                            TMT_CONTENTMARGINS, &rectBtn, &margins);
+    if (::GetThemeMargins(theme, hdc, BP_PUSHBUTTON, iState,
+                          TMT_CONTENTMARGINS, &rectBtn,
+                          &margins) != S_OK)
+        wxZeroMemory(margins);
+
     ::InflateRect(&rectBtn, -margins.cxLeftWidth, -margins.cyTopHeight);
-    ::InflateRect(&rectBtn, -XP_BUTTON_EXTRA_MARGIN, -XP_BUTTON_EXTRA_MARGIN);
 
     if ( button->UseBgCol() && iState != PBS_HOT )
     {

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -302,24 +302,30 @@ void MenuDrawData::Init()
         wxWindow* window = static_cast<wxApp*>(wxApp::GetInstance())->GetTopWindow();
         wxUxThemeHandle hTheme(window, L"MENU");
 
-        ::GetThemeMargins(hTheme, NULL, MENU_POPUPITEM, 0,
-                               TMT_CONTENTMARGINS, NULL,
-                               &ItemMargin);
+        if (::GetThemeMargins(hTheme, NULL, MENU_POPUPITEM, 0,
+                              TMT_CONTENTMARGINS, NULL,
+                              &ItemMargin) != S_OK)
+            wxZeroMemory(ItemMargin);
 
-        ::GetThemeMargins(hTheme, NULL, MENU_POPUPCHECK, 0,
-                               TMT_CONTENTMARGINS, NULL,
-                               &CheckMargin);
-        ::GetThemeMargins(hTheme, NULL, MENU_POPUPCHECKBACKGROUND, 0,
-                               TMT_CONTENTMARGINS, NULL,
-                               &CheckBgMargin);
+        if (::GetThemeMargins(hTheme, NULL, MENU_POPUPCHECK, 0,
+                              TMT_CONTENTMARGINS, NULL,
+                              &CheckMargin) != S_OK)
+            wxZeroMemory(CheckMargin);
 
-        ::GetThemeMargins(hTheme, NULL, MENU_POPUPSUBMENU, 0,
-                               TMT_CONTENTMARGINS, NULL,
-                               &ArrowMargin);
+        if (::GetThemeMargins(hTheme, NULL, MENU_POPUPCHECKBACKGROUND, 0,
+                              TMT_CONTENTMARGINS, NULL,
+                              &CheckBgMargin) != S_OK)
+            wxZeroMemory(CheckBgMargin);
 
-        ::GetThemeMargins(hTheme, NULL, MENU_POPUPSEPARATOR, 0,
-                               TMT_SIZINGMARGINS, NULL,
-                               &SeparatorMargin);
+        if (::GetThemeMargins(hTheme, NULL, MENU_POPUPSUBMENU, 0,
+                              TMT_CONTENTMARGINS, NULL,
+                              &ArrowMargin) != S_OK)
+            wxZeroMemory(ArrowMargin);
+
+        if (::GetThemeMargins(hTheme, NULL, MENU_POPUPSEPARATOR, 0,
+                              TMT_SIZINGMARGINS, NULL,
+                              &SeparatorMargin) != S_OK)
+            wxZeroMemory(SeparatorMargin);
 
         ::GetThemePartSize(hTheme, NULL, MENU_POPUPCHECK, 0,
                                 NULL, TS_TRUE, &CheckSize);


### PR DESCRIPTION
Any call to MSW GetThemeMargins API, must check its return value, and if it is different than S_OK, then we should reset all pMargins struct members to zero, otherwise it may contain invalid values that will cause improper drawing.