### PR TITLE
Fix generic wxSearchCtrl drawings.

### DIFF
--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -22,7 +22,7 @@
     #include "wx/button.h"
     #include "wx/dcclient.h"
     #include "wx/menu.h"
-    #include "wx/dcmemory.h"
+    #include "wx/dcbuffer.h"
 #endif //WX_PRECOMP
 
 #if !wxUSE_NATIVE_SEARCH_CONTROL
@@ -31,15 +31,15 @@
 #include "wx/utils.h"
 
 // ----------------------------------------------------------------------------
-// constants
+// Constants
 // ----------------------------------------------------------------------------
 
-// the margin between the text control and the search/cancel buttons
+// The margin between the text control and the Search/Cancel buttons
 static const wxCoord MARGIN = 2;
 
-// arguments to wxColour::ChangeLightness() for making the search/cancel
+// Arguments to wxColour::ChangeLightness() for making the Search/Cancel
 // bitmaps foreground colour, respectively
-static const int SEARCH_BITMAP_LIGHTNESS = 140; // slightly lighter
+static const int SEARCH_BITMAP_LIGHTNESS = 140; // Slightly lighter
 static const int CANCEL_BITMAP_LIGHTNESS = 160; // a bit more lighter
 
 // ----------------------------------------------------------------------------
@@ -51,14 +51,14 @@ class wxSearchTextCtrl : public wxTextCtrl
 public:
     wxSearchTextCtrl(wxSearchCtrl *search, const wxString& value, int style)
         : wxTextCtrl(search, wxID_ANY, value, wxDefaultPosition, wxDefaultSize,
-                     (style & ~wxBORDER_MASK) | wxNO_BORDER | wxTE_PROCESS_ENTER)
+                     (style & ~wxBORDER_MASK) | wxBORDER_NONE | wxTE_PROCESS_ENTER)
     {
         m_search = search;
 
         SetHint(_("Search"));
 
         // Ensure that our best size is recomputed using our overridden
-        // DoGetBestSize().
+        // DoGetBestSize()
         InvalidateBestSize();
     }
 
@@ -67,7 +67,7 @@ public:
         return m_search;
     }
 
-    // provide access to the base class protected methods to wxSearchCtrl which
+    // Provide access to the base class protected methods to wxSearchCtrl which
     // needs to forward to them
     void DoSetValue(const wxString& value, int flags) wxOVERRIDE
     {
@@ -96,7 +96,7 @@ protected:
 
     void OnTextEnter(wxCommandEvent& WXUNUSED(event))
     {
-        if ( !IsEmpty() )
+        if (!IsEmpty())
         {
             wxCommandEvent event(wxEVT_SEARCH, m_search->GetId());
             event.SetEventObject(m_search);
@@ -141,7 +141,7 @@ protected:
 #endif // __WXMSW__
 
 private:
-    wxSearchCtrl* m_search;
+    wxSearchCtrl *m_search;
 
     wxDECLARE_EVENT_TABLE();
 };
@@ -160,7 +160,7 @@ class wxSearchButton : public wxControl
 {
 public:
     wxSearchButton(wxSearchCtrl *search, int eventType, const wxBitmap& bmp)
-        : wxControl(search, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNO_BORDER),
+        : wxControl(search, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE),
           m_search(search),
           m_eventType(eventType),
           m_bmp(bmp)
@@ -198,31 +198,33 @@ protected:
         wxCommandEvent event(m_eventType, m_search->GetId());
         event.SetEventObject(m_search);
 
-        if ( m_eventType == wxEVT_SEARCH )
-        {
-            // it's convenient to have the string to search for directly in the
+        if (m_eventType == wxEVT_SEARCH)
+            // It's convenient to have the string to search for directly in the
             // event instead of having to retrieve it from the control in the
             // event handler code later, so provide it here
             event.SetString(m_search->GetValue());
-        }
 
         GetEventHandler()->ProcessEvent(event);
-
         m_search->SetFocus();
 
 #if wxUSE_MENUS
-        if ( m_eventType == wxEVT_SEARCH )
-        {
-            // this happens automatically, just like on Mac OS X
+        if (m_eventType == wxEVT_SEARCH)
+            // This happens automatically, just like on Mac OS X
             m_search->PopupSearchMenu();
-        }
 #endif // wxUSE_MENUS
     }
 
     void OnPaint(wxPaintEvent&)
     {
-        wxPaintDC dc(this);
-        dc.DrawBitmap(m_bmp, 0,0, true);
+        wxAutoBufferedPaintDC bufPaintDC(this);
+        
+        // Clear the background in case of a user bitmap with alpha channel
+        wxColour bg = m_search->GetBackgroundColour();
+        bufPaintDC.SetBrush(wxBrush(bg));
+        bufPaintDC.SetPen(wxPen(bg));
+        bufPaintDC.Clear();
+        //bufPaintDC.DrawRectangle(0, 0, m_bmp.GetWidth(), m_bmp.GetHeight());
+        bufPaintDC.DrawBitmap(m_bmp, 0, 0, true);
     }
 
 
@@ -247,14 +249,14 @@ wxEND_EVENT_TABLE()
 wxIMPLEMENT_DYNAMIC_CLASS(wxSearchCtrl, wxSearchCtrlBase);
 
 // ============================================================================
-// implementation
+// Implementation
 // ============================================================================
 
 // ----------------------------------------------------------------------------
 // wxSearchCtrl creation
 // ----------------------------------------------------------------------------
 
-// creation
+// Creation
 // --------
 
 wxSearchCtrl::wxSearchCtrl()
@@ -262,13 +264,14 @@ wxSearchCtrl::wxSearchCtrl()
     Init();
 }
 
-wxSearchCtrl::wxSearchCtrl(wxWindow *parent, wxWindowID id,
-           const wxString& value,
-           const wxPoint& pos,
-           const wxSize& size,
-           long style,
-           const wxValidator& validator,
-           const wxString& name)
+wxSearchCtrl::wxSearchCtrl(wxWindow *parent,
+                           wxWindowID id,
+                           const wxString& value,
+                           const wxPoint& pos,
+                           const wxSize& size,
+                           long style,
+                           const wxValidator& validator,
+                           const wxString& name)
 {
     Init();
 
@@ -291,19 +294,18 @@ void wxSearchCtrl::Init()
 #endif // wxUSE_MENUS
 }
 
-bool wxSearchCtrl::Create(wxWindow *parent, wxWindowID id,
-            const wxString& value,
-            const wxPoint& pos,
-            const wxSize& size,
-            long style,
-            const wxValidator& validator,
-            const wxString& name)
+bool wxSearchCtrl::Create(wxWindow *parent,
+                          wxWindowID id,
+                          const wxString& value,
+                          const wxPoint& pos,
+                          const wxSize& size,
+                          long style,
+                          const wxValidator& validator,
+                          const wxString& name)
 {
-    if ( !wxSearchCtrlBaseBaseClass::Create(parent, id, pos, size,
-                                            style, validator, name) )
-    {
+    if (!wxSearchCtrlBaseBaseClass::Create(parent, id, pos, size,
+                                           style, validator, name))
         return false;
-    }
 
     m_text = new wxSearchTextCtrl(this, value, style);
 
@@ -311,13 +313,16 @@ bool wxSearchCtrl::Create(wxWindow *parent, wxWindowID id,
                                         wxEVT_SEARCH,
                                         m_searchBitmap);
 
-    SetBackgroundColour( m_text->GetBackgroundColour() );
-    m_text->SetBackgroundColour(wxColour());
+    m_cancelButton = new wxSearchButton(this,
+                                        wxEVT_SEARCH_CANCEL,
+                                        m_cancelBitmap);
 
+    SetBackgroundColour(m_text->GetBackgroundColour());
+    //m_text->SetBackgroundColour(wxColour());
     RecalcBitmaps();
-
     SetInitialSize(size);
     Move(pos);
+
     return true;
 }
 
@@ -332,34 +337,33 @@ wxSearchCtrl::~wxSearchCtrl()
 }
 
 
-// search control specific interfaces
+// Search control specific interfaces
 #if wxUSE_MENUS
 
-void wxSearchCtrl::SetMenu( wxMenu* menu )
+void wxSearchCtrl::SetMenu(wxMenu *menu)
 {
-    if ( menu == m_menu )
-    {
-        // no change
+    if (menu == m_menu)
+        // No change
         return;
-    }
+
     bool hadMenu = (m_menu != NULL);
     delete m_menu;
     m_menu = menu;
 
-    if ( m_menu && !hadMenu )
+    if (m_menu && !hadMenu)
     {
         m_searchButton->Show();
         m_searchButton->SetBitmapLabel(m_searchMenuBitmap);
         m_searchButton->Refresh();
     }
-    else if ( !m_menu && hadMenu )
+    else if (!m_menu && hadMenu)
     {
         m_searchButton->SetBitmapLabel(m_searchBitmap);
-        if ( m_searchButton->IsShown() )
-        {
+
+        if (m_searchButton->IsShown())
             m_searchButton->Refresh();
-        }
     }
+
     LayoutControls();
 }
 
@@ -370,26 +374,22 @@ wxMenu* wxSearchCtrl::GetMenu()
 
 #endif // wxUSE_MENUS
 
-void wxSearchCtrl::ShowSearchButton( bool show )
+void wxSearchCtrl::ShowSearchButton(bool show)
 {
-    if ( show == IsSearchButtonVisible() )
-    {
-        // no change
+    if (show == IsSearchButtonVisible())
+        // No change
         return;
-    }
-    if ( show )
+
+    if (show)
     {
         RecalcBitmaps();
-
         m_searchButton->Show();
     }
     else // Requested to hide it.
-    {
         // Only hide the button if we don't need it for the menu, otherwise it
         // needs to remain shown.
-        if ( !HasMenu() )
+        if (!HasMenu())
             m_searchButton->Hide();
-    }
 
     LayoutControls();
 }
@@ -400,32 +400,26 @@ bool wxSearchCtrl::IsSearchButtonVisible() const
 }
 
 
-void wxSearchCtrl::ShowCancelButton( bool show )
+void wxSearchCtrl::ShowCancelButton(bool show)
 {
-    if ( show == IsCancelButtonVisible() )
-    {
-        // no change
+    if (show == IsCancelButtonVisible())
+        // No change
         return;
-    }
 
-    // This button is not shown initially, so create it on demand if necessary,
-    // i.e. if it's the first time we show it.
-    if ( !m_cancelButton )
+    if (show)
     {
-        m_cancelButton = new wxSearchButton(this,
-                                            wxEVT_SEARCH_CANCEL,
-                                            m_cancelBitmap);
         RecalcBitmaps();
+        m_cancelButton->Show();
     }
-
-    m_cancelButton->Show(show);
-
+    else // Requested to hide it.
+            m_cancelButton->Hide();
+    
     LayoutControls();
 }
 
 bool wxSearchCtrl::IsCancelButtonVisible() const
 {
-    return m_cancelButton && m_cancelButton->IsShown();
+    return m_cancelButton->IsShown();
 }
 
 void wxSearchCtrl::SetDescriptiveText(const wxString& text)
@@ -439,101 +433,112 @@ wxString wxSearchCtrl::GetDescriptiveText() const
 }
 
 // ----------------------------------------------------------------------------
-// geometry
+// Geometry
 // ----------------------------------------------------------------------------
 
 wxSize wxSearchCtrl::DoGetBestClientSize() const
 {
     wxSize sizeText = m_text->GetBestSize();
-    wxSize sizeSearch(0,0);
-    wxSize sizeCancel(0,0);
+    wxSize sizeSearch(0, 0);
+    wxSize sizeCancel(0, 0);
     int searchMargin = 0;
     int cancelMargin = 0;
-    if ( IsSearchButtonVisible() )
+
+    if (IsSearchButtonVisible())
     {
         sizeSearch = m_searchButton->GetBestSize();
         searchMargin = FromDIP(MARGIN);
     }
-    if ( IsCancelButtonVisible() )
+
+    if (IsCancelButtonVisible())
     {
         sizeCancel = m_cancelButton->GetBestSize();
         cancelMargin = FromDIP(MARGIN);
     }
 
-    int horizontalBorder = FromDIP(1) + ( sizeText.y - sizeText.y * 14 / 21 ) / 2;
+    const int horizontalBorder = (sizeText.y - sizeText.y * 14 / 20) / 2;
 
-    // buttons are square and equal to the height of the text control
-    int height = sizeText.y;
-    return wxSize(sizeSearch.x + searchMargin + sizeText.x + cancelMargin + sizeCancel.x + 2*horizontalBorder,
-                  height);
+    // Buttons are square and equal to the height of the text control
+
+    return wxSize(sizeSearch.x + searchMargin + sizeText.x + cancelMargin
+                  + sizeCancel.x + 2 * horizontalBorder, sizeText.y);
 }
 
 void wxSearchCtrl::LayoutControls()
 {
-    if ( !m_text )
+    if (!m_text)
         return;
 
     const wxSize sizeTotal = GetClientSize();
-    int width = sizeTotal.x,
-        height = sizeTotal.y;
-
+    const int width = sizeTotal.x,
+              height = sizeTotal.y;
     wxSize sizeText = m_text->GetBestSize();
-    // make room for the search menu & clear button
-    int horizontalBorder = FromDIP(1) + ( sizeText.y - sizeText.y * 14 / 21 ) / 2;
-    int x = horizontalBorder;
-    width -= horizontalBorder*2;
-    if (width < 0) width = 0;
 
-    wxSize sizeSearch(0,0);
-    wxSize sizeCancel(0,0);
+    // Make room for the search menu & clear button
+    const int horizontalBorder = (sizeText.y - sizeText.y * 14 / 20) / 2;
+    int x = 0;
+    int textWidth = width;
+
+    wxSize sizeSearch(0, 0);
+    wxSize sizeCancel(0, 0);
     int searchMargin = 0;
     int cancelMargin = 0;
-    if ( IsSearchButtonVisible() )
+
+    if (IsSearchButtonVisible())
     {
         sizeSearch = m_searchButton->GetBestSize();
         searchMargin = FromDIP(MARGIN);
+        x += horizontalBorder;
+        textWidth -= horizontalBorder;
     }
-    if ( IsCancelButtonVisible() )
+
+    if (IsCancelButtonVisible())
     {
         sizeCancel = m_cancelButton->GetBestSize();
         cancelMargin = FromDIP(MARGIN);
+        textWidth -= horizontalBorder;
     }
 
-    if ( sizeSearch.x + sizeCancel.x > width )
+    if ((sizeSearch.x + sizeCancel.x) > width)
     {
-        sizeSearch.x = width/2;
-        sizeCancel.x = width/2;
+        sizeSearch.x = width / 2;
+        sizeCancel.x = width / 2;
         searchMargin = 0;
         cancelMargin = 0;
     }
-    wxCoord textWidth = width - sizeSearch.x - sizeCancel.x - searchMargin - cancelMargin - FromDIP(1);
-    if (textWidth < 0) textWidth = 0;
 
-    // position the subcontrols inside the client area
+    textWidth -= sizeSearch.x + searchMargin + cancelMargin + sizeCancel.x;
 
-    m_searchButton->SetSize(x, (height - sizeSearch.y) / 2,
-                            sizeSearch.x, sizeSearch.y);
-    x += sizeSearch.x;
-    x += searchMargin;
+    if (textWidth < 0)
+        textWidth = 0;
+
+    // Position the subcontrols inside the client area
+    if (m_searchButton)
+    {
+        m_searchButton->SetSize(x, (height - sizeSearch.y) / 2,
+                                sizeSearch.x, sizeSearch.y);
+        x += sizeSearch.x;
+        x += searchMargin;
+    }
+
+    int textY = 0;
 
 #ifdef __WXMSW__
     // The text control is too high up on Windows; normally a text control looks OK because
     // of the white border that's part of the theme border. We can also remove a pixel from
     // the height to fit the text control in, because the padding in EDIT_HEIGHT_FROM_CHAR_HEIGHT
     // is already generous.
-    int textY = FromDIP(2);
-#else
-    int textY = 0;
-#endif
+    textY = FromDIP(2);
+#endif // __WXMSW__
 
-    m_text->SetSize(x, textY, textWidth, height-textY);
+    m_text->SetSize(x, textY, textWidth, height - textY);
     x += textWidth;
-    x += cancelMargin;
 
-    if ( m_cancelButton )
+    if (m_cancelButton)
     {
+        x += cancelMargin;
         m_cancelButton->SetSize(x, (height - sizeCancel.y) / 2,
-                                sizeCancel.x, height);
+                                sizeCancel.x, sizeCancel.y);
     }
 }
 
@@ -543,16 +548,18 @@ wxWindowList wxSearchCtrl::GetCompositeWindowParts() const
     parts.push_back(m_text);
     parts.push_back(m_searchButton);
     parts.push_back(m_cancelButton);
+
     return parts;
 }
 
-// accessors
+// Accessors
 // ---------
 
 wxString wxSearchCtrl::DoGetValue() const
 {
     return m_text->GetValue();
 }
+
 wxString wxSearchCtrl::GetRange(long from, long to) const
 {
     return m_text->GetRange(from, to);
@@ -562,10 +569,12 @@ int wxSearchCtrl::GetLineLength(long lineNo) const
 {
     return m_text->GetLineLength(lineNo);
 }
+
 wxString wxSearchCtrl::GetLineText(long lineNo) const
 {
     return m_text->GetLineText(lineNo);
 }
+
 int wxSearchCtrl::GetNumberOfLines() const
 {
     return m_text->GetNumberOfLines();
@@ -575,16 +584,18 @@ bool wxSearchCtrl::IsModified() const
 {
     return m_text->IsModified();
 }
+
 bool wxSearchCtrl::IsEditable() const
 {
     return m_text->IsEditable();
 }
 
-// more readable flag testing methods
+// More readable flag testing methods
 bool wxSearchCtrl::IsSingleLine() const
 {
     return m_text->IsSingleLine();
 }
+
 bool wxSearchCtrl::IsMultiLine() const
 {
     return m_text->IsMultiLine();
@@ -601,95 +612,104 @@ wxString wxSearchCtrl::GetStringSelection() const
     return m_text->GetStringSelection();
 }
 
-// operations
+// Operations
 // ----------
 
-// editing
+// Editing
 void wxSearchCtrl::Clear()
 {
     m_text->Clear();
 }
+
 void wxSearchCtrl::Replace(long from, long to, const wxString& value)
 {
     m_text->Replace(from, to, value);
 }
+
 void wxSearchCtrl::Remove(long from, long to)
 {
     m_text->Remove(from, to);
 }
 
-// load/save the controls contents from/to the file
+// Load/Save the controls contents from/to the file
 bool wxSearchCtrl::LoadFile(const wxString& file)
 {
     return m_text->LoadFile(file);
 }
+
 bool wxSearchCtrl::SaveFile(const wxString& file)
 {
     return m_text->SaveFile(file);
 }
 
-// sets/clears the dirty flag
+// Sets/Clears the dirty flag
 void wxSearchCtrl::MarkDirty()
 {
     m_text->MarkDirty();
 }
+
 void wxSearchCtrl::DiscardEdits()
 {
     m_text->DiscardEdits();
 }
 
-// set the max number of characters which may be entered in a single line
+// Set the max number of characters which may be entered in a single line
 // text control
 void wxSearchCtrl::SetMaxLength(unsigned long len)
 {
     m_text->SetMaxLength(len);
 }
 
-// writing text inserts it at the current position, appending always
+// Writing text inserts it at the current position, appending always
 // inserts it at the end
 void wxSearchCtrl::WriteText(const wxString& text)
 {
     m_text->WriteText(text);
 }
+
 void wxSearchCtrl::AppendText(const wxString& text)
 {
     m_text->AppendText(text);
 }
 
-// insert the character which would have resulted from this key event,
+// Insert the character which would have resulted from this key event,
 // return true if anything has been inserted
 bool wxSearchCtrl::EmulateKeyPress(const wxKeyEvent& event)
 {
     return m_text->EmulateKeyPress(event);
 }
 
-// text control under some platforms supports the text styles: these
+// Text control under some platforms supports the text styles: these
 // methods allow to apply the given text style to the given selection or to
 // set/get the style which will be used for all appended text
 bool wxSearchCtrl::SetStyle(long start, long end, const wxTextAttr& style)
 {
     return m_text->SetStyle(start, end, style);
 }
+
 bool wxSearchCtrl::GetStyle(long position, wxTextAttr& style)
 {
     return m_text->GetStyle(position, style);
 }
+
 bool wxSearchCtrl::SetDefaultStyle(const wxTextAttr& style)
 {
     return m_text->SetDefaultStyle(style);
 }
+
 const wxTextAttr& wxSearchCtrl::GetDefaultStyle() const
 {
     return m_text->GetDefaultStyle();
 }
 
-// translate between the position (which is just an index in the text ctrl
+// Translate between the position (which is just an index in the text ctrl
 // considering all its contents as a single strings) and (x, y) coordinates
 // which represent column and line.
 long wxSearchCtrl::XYToPosition(long x, long y) const
 {
     return m_text->XYToPosition(x, y);
 }
+
 bool wxSearchCtrl::PositionToXY(long pos, long *x, long *y) const
 {
     return m_text->PositionToXY(pos, x, y);
@@ -700,7 +720,7 @@ void wxSearchCtrl::ShowPosition(long pos)
     m_text->ShowPosition(pos);
 }
 
-// find the character at position given in pixels
+// Find the character at position given in pixels
 //
 // NB: pt is in device coords (not adjusted for the client area origin nor
 //     scrolling)
@@ -708,9 +728,10 @@ wxTextCtrlHitTestResult wxSearchCtrl::HitTest(const wxPoint& pt, long *pos) cons
 {
     return m_text->HitTest(pt, pos);
 }
+
 wxTextCtrlHitTestResult wxSearchCtrl::HitTest(const wxPoint& pt,
-                                        wxTextCoord *col,
-                                        wxTextCoord *row) const
+                                              wxTextCoord *col,
+                                              wxTextCoord *row) const
 {
     return m_text->HitTest(pt, col, row);
 }
@@ -720,10 +741,12 @@ void wxSearchCtrl::Copy()
 {
     m_text->Copy();
 }
+
 void wxSearchCtrl::Cut()
 {
     m_text->Cut();
 }
+
 void wxSearchCtrl::Paste()
 {
     m_text->Paste();
@@ -733,20 +756,23 @@ bool wxSearchCtrl::CanCopy() const
 {
     return m_text->CanCopy();
 }
+
 bool wxSearchCtrl::CanCut() const
 {
     return m_text->CanCut();
 }
+
 bool wxSearchCtrl::CanPaste() const
 {
     return m_text->CanPaste();
 }
 
-// Undo/redo
+// Undo/Redo
 void wxSearchCtrl::Undo()
 {
     m_text->Undo();
 }
+
 void wxSearchCtrl::Redo()
 {
     m_text->Redo();
@@ -756,6 +782,7 @@ bool wxSearchCtrl::CanUndo() const
 {
     return m_text->CanUndo();
 }
+
 bool wxSearchCtrl::CanRedo() const
 {
     return m_text->CanRedo();
@@ -766,14 +793,17 @@ void wxSearchCtrl::SetInsertionPoint(long pos)
 {
     m_text->SetInsertionPoint(pos);
 }
+
 void wxSearchCtrl::SetInsertionPointEnd()
 {
     m_text->SetInsertionPointEnd();
 }
+
 long wxSearchCtrl::GetInsertionPoint() const
 {
     return m_text->GetInsertionPoint();
 }
+
 long wxSearchCtrl::GetLastPosition() const
 {
     return m_text->GetLastPosition();
@@ -783,6 +813,7 @@ void wxSearchCtrl::SetSelection(long from, long to)
 {
     m_text->SetSelection(from, to);
 }
+
 void wxSearchCtrl::SelectAll()
 {
     m_text->SelectAll();
@@ -795,7 +826,7 @@ void wxSearchCtrl::SetEditable(bool editable)
 
 bool wxSearchCtrl::SetFont(const wxFont& font)
 {
-    if ( !wxSearchCtrlBase::SetFont(font) )
+    if (!wxSearchCtrlBase::SetFont(font))
         return false;
 
     // Recreate the bitmaps as their size may have changed.
@@ -806,7 +837,7 @@ bool wxSearchCtrl::SetFont(const wxFont& font)
 
 bool wxSearchCtrl::SetBackgroundColour(const wxColour& colour)
 {
-    if ( !wxSearchCtrlBase::SetBackgroundColour(colour) )
+    if (!wxSearchCtrlBase::SetBackgroundColour(colour))
         return false;
 
     // When the background changes, re-render the bitmaps so that the correct
@@ -816,11 +847,10 @@ bool wxSearchCtrl::SetBackgroundColour(const wxColour& colour)
     return true;
 }
 
-
 // Autocomplete
 bool wxSearchCtrl::DoAutoCompleteStrings(const wxArrayString &choices)
 {
-    return m_text->AutoComplete( choices );
+    return m_text->AutoComplete(choices);
 }
 
 bool wxSearchCtrl::DoAutoCompleteFileNames(int flags)
@@ -833,64 +863,54 @@ bool wxSearchCtrl::DoAutoCompleteCustom(wxTextCompleter *completer)
     return m_text->AutoComplete(completer);
 }
 
-
-// search control generic only
-void wxSearchCtrl::SetSearchBitmap( const wxBitmap& bitmap )
+// Search control generic only
+void wxSearchCtrl::SetSearchBitmap(const wxBitmap& bitmap)
 {
     m_searchBitmap = bitmap;
     m_searchBitmapUser = bitmap.IsOk();
-    if ( m_searchBitmapUser )
+
+    if (m_searchBitmapUser)
     {
-        if ( m_searchButton && !HasMenu() )
-        {
-            m_searchButton->SetBitmapLabel( m_searchBitmap );
-        }
+        if (m_searchButton && !HasMenu())
+            m_searchButton->SetBitmapLabel(m_searchBitmap);
     }
     else
-    {
-        // the user bitmap was just cleared, generate one
+        // The user bitmap was just cleared, generate one
         RecalcBitmaps();
-    }
 }
 
 #if wxUSE_MENUS
 
-void wxSearchCtrl::SetSearchMenuBitmap( const wxBitmap& bitmap )
+void wxSearchCtrl::SetSearchMenuBitmap(const wxBitmap& bitmap)
 {
     m_searchMenuBitmap = bitmap;
     m_searchMenuBitmapUser = bitmap.IsOk();
-    if ( m_searchMenuBitmapUser )
+
+    if (m_searchMenuBitmapUser)
     {
-        if ( m_searchButton && m_menu )
-        {
-            m_searchButton->SetBitmapLabel( m_searchMenuBitmap );
-        }
+        if (m_searchButton && m_menu)
+            m_searchButton->SetBitmapLabel(m_searchMenuBitmap);
     }
     else
-    {
-        // the user bitmap was just cleared, generate one
+        // The user bitmap was just cleared, generate one
         RecalcBitmaps();
-    }
 }
 
 #endif // wxUSE_MENUS
 
-void wxSearchCtrl::SetCancelBitmap( const wxBitmap& bitmap )
+void wxSearchCtrl::SetCancelBitmap(const wxBitmap& bitmap)
 {
     m_cancelBitmap = bitmap;
     m_cancelBitmapUser = bitmap.IsOk();
-    if ( m_cancelBitmapUser )
+
+    if (m_cancelBitmapUser)
     {
-        if ( m_cancelButton )
-        {
-            m_cancelButton->SetBitmapLabel( m_cancelBitmap );
-        }
+        if (m_cancelButton)
+            m_cancelButton->SetBitmapLabel(m_cancelBitmap);
     }
     else
-    {
-        // the user bitmap was just cleared, generate one
+        // The user bitmap was just cleared, generate one
         RecalcBitmaps();
-    }
 }
 
 // Note that overriding DoSetValue() is currently insufficient because the base
@@ -921,22 +941,21 @@ bool wxSearchCtrl::ShouldInheritColours() const
     return true;
 }
 
-// icons are rendered at 3-8 times larger than necessary and downscaled for
+// Icons are rendered at 3-8 times larger than necessary and downscaled for
 // antialiasing
 static int GetMultiplier()
 {
     int depth = ::wxDisplayDepth();
 
-    if  ( depth >= 24 )
-    {
+    if (depth >= 24)
         return 8;
-    }
+
     return 6;
 }
 
 static void RescaleBitmap(wxBitmap& bmp, const wxSize& sizeNeeded)
 {
-    wxCHECK_RET( sizeNeeded.IsFullySpecified(), wxS("New size must be given") );
+    wxCHECK_RET(sizeNeeded.IsFullySpecified(), wxS("New size must be given"));
 
 #if wxUSE_IMAGE
     wxImage img = bmp.ConvertToImage();
@@ -950,7 +969,7 @@ static void RescaleBitmap(wxBitmap& bmp, const wxSize& sizeNeeded)
     newBmp.UseAlpha(bmp.HasAlpha());
 #endif // __WXMSW__ || __WXOSX__
     {
-        wxMemoryDC dc(newBmp);
+        wxBufferedDC dc(NULL, newBmp);
         double scX = (double)sizeNeeded.GetWidth() / bmp.GetWidth();
         double scY = (double)sizeNeeded.GetHeight() / bmp.GetHeight();
         dc.SetUserScale(scX, scY);
@@ -960,261 +979,245 @@ static void RescaleBitmap(wxBitmap& bmp, const wxSize& sizeNeeded)
 #endif // wxUSE_IMAGE/!wxUSE_IMAGE
 }
 
-wxBitmap wxSearchCtrl::RenderSearchBitmap( int x, int y, bool renderDrop )
+wxBitmap wxSearchCtrl::RenderSearchBitmap(int x, int y, bool renderDrop)
 {
     wxColour bg = GetBackgroundColour();
     wxColour fg = GetForegroundColour().ChangeLightness(SEARCH_BITMAP_LIGHTNESS);
 
     //===============================================================================
-    // begin drawing code
+    // Begin of drawing code
     //===============================================================================
-    // image stats
+    // Image stats
 
-    // force width:height ratio
-    if ( 14*x > y*20 )
-    {
+    // Force a width:height ratio
+    if (x * 14 > y * 20)
         // x is too big
-        x = y*20/14;
-    }
+        x = y * 20 / 14;
     else
-    {
         // y is too big
-        y = x*14/20;
-    }
+        y = x * 14 / 20;
 
-    // glass 11x11, top left corner
-    // handle (9,9)-(13,13)
-    // drop (13,16)-(19,6)-(16,9)
+    // Glass:  11x11, top left corner
+    // Handle: (9,9)-(13,13)
+    // Drop:   (13,16)-(19,6)-(16,9)
 
     int multiplier = GetMultiplier();
     int penWidth = multiplier * 2;
 
     penWidth = penWidth * x / 20;
 
-    wxBitmap bitmap( multiplier*x, multiplier*y );
-    wxMemoryDC mem;
-    mem.SelectObject(bitmap);
+    wxBitmap bitmap(multiplier * x, multiplier * y);
+    wxBufferedDC bufDC(NULL, bitmap);
 
-    // clear background
-    mem.SetBrush( wxBrush(bg) );
-    mem.SetPen( wxPen(bg) );
-    mem.DrawRectangle(0,0,bitmap.GetWidth(),bitmap.GetHeight());
+    // Clear the background
+    bufDC.SetBrush(wxBrush(bg));
+    bufDC.SetPen(wxPen(bg));
+    //bufDC.Clear();
+    bufDC.DrawRectangle(0, 0, bitmap.GetWidth(), bitmap.GetHeight());
 
-    // draw drop glass
-    mem.SetBrush( wxBrush(fg) );
-    mem.SetPen( wxPen(fg) );
+    // Draw the glass
+    bufDC.SetBrush(wxBrush(fg));
+    bufDC.SetPen(wxPen(fg));
     int glassBase = 5 * x / 20;
-    int glassFactor = 2*glassBase + 1;
-    int radius = multiplier*glassFactor/2;
-    mem.DrawCircle(radius,radius,radius);
-    mem.SetBrush( wxBrush(bg) );
-    mem.SetPen( wxPen(bg) );
-    mem.DrawCircle(radius,radius,radius-penWidth);
+    int glassFactor = 2 * glassBase + 1;
+    int radius = multiplier * glassFactor / 2;
+    bufDC.DrawCircle(radius, radius, radius);
+    bufDC.SetBrush(wxBrush(bg));
+    bufDC.SetPen(wxPen(bg));
+    bufDC.DrawCircle(radius, radius, radius - penWidth);
 
-    // draw handle
-    int lineStart = radius + (radius-penWidth/2) * 707 / 1000; // 707 / 1000 = 0.707 = 1/sqrt(2);
+    // Draw the handle
+    int lineStart = radius + (radius - penWidth / 2) * 707 / 1000; // 707 / 1000 = 0.707 = 1 / sqrt(2);
 
-    mem.SetPen( wxPen(fg) );
-    mem.SetBrush( wxBrush(fg) );
-    int handleCornerShift = penWidth * 707 / 1000 / 2; // 707 / 1000 = 0.707 = 1/sqrt(2);
-    handleCornerShift = wxMax( handleCornerShift, 1 );
+    bufDC.SetPen(wxPen(fg));
+    bufDC.SetBrush(wxBrush(fg));
+    int handleCornerShift = penWidth * 707 / 1000 / 2; // 707 / 1000 = 0.707 = 1 / sqrt(2);
+    handleCornerShift = wxMax(handleCornerShift, 1);
     int handleBase = 4 * x / 20;
-    int handleLength = 2*handleBase+1;
+    int handleLength = 2 * handleBase + 1;
+
     wxPoint handlePolygon[] =
     {
-        wxPoint(-handleCornerShift,+handleCornerShift),
-        wxPoint(+handleCornerShift,-handleCornerShift),
-        wxPoint(multiplier*handleLength/2+handleCornerShift,multiplier*handleLength/2-handleCornerShift),
-        wxPoint(multiplier*handleLength/2-handleCornerShift,multiplier*handleLength/2+handleCornerShift),
+        wxPoint(-handleCornerShift, +handleCornerShift),
+        wxPoint(+handleCornerShift, -handleCornerShift),
+        wxPoint(multiplier * handleLength / 2 + handleCornerShift, multiplier * handleLength / 2 - handleCornerShift),
+        wxPoint(multiplier * handleLength / 2 - handleCornerShift, multiplier * handleLength / 2 + handleCornerShift),
     };
-    mem.DrawPolygon(WXSIZEOF(handlePolygon),handlePolygon,lineStart,lineStart);
+    bufDC.DrawPolygon(WXSIZEOF(handlePolygon), handlePolygon, lineStart, lineStart);
 
-    // draw drop triangle
+    // Draw the drop triangle
     int triangleX = 13 * x / 20;
     int triangleY = 5 * x / 20;
     int triangleBase = 3 * x / 20;
-    int triangleFactor = triangleBase*2+1;
-    if ( renderDrop )
+    int triangleFactor = triangleBase * 2 + 1;
+
+    if (renderDrop)
     {
         wxPoint dropPolygon[] =
         {
-            wxPoint(multiplier*0,multiplier*0), // triangle left
-            wxPoint(multiplier*triangleFactor-1,multiplier*0), // triangle right
-            wxPoint(multiplier*triangleFactor/2,multiplier*triangleFactor/2), // triangle bottom
+            wxPoint(multiplier * 0, multiplier * 0), // Triangle left
+            wxPoint(multiplier * triangleFactor - 1, multiplier * 0), // Triangle right
+            wxPoint(multiplier * triangleFactor / 2, multiplier * triangleFactor / 2), // Triangle bottom
         };
-        mem.DrawPolygon(WXSIZEOF(dropPolygon),dropPolygon,multiplier*triangleX,multiplier*triangleY);
+        bufDC.DrawPolygon(WXSIZEOF(dropPolygon), dropPolygon, multiplier * triangleX, multiplier * triangleY);
     }
-    mem.SelectObject(wxNullBitmap);
+
+    bufDC.SelectObject(wxNullBitmap);
 
     //===============================================================================
-    // end drawing code
+    // End of drawing code
     //===============================================================================
 
-    if ( multiplier != 1 )
-    {
+    if (multiplier != 1)
         RescaleBitmap(bitmap, wxSize(x, y));
-    }
-    if ( !renderDrop )
-    {
+
+    if (!renderDrop)
         // Trim the edge where the arrow would have gone
-        bitmap = bitmap.GetSubBitmap(wxRect(0,0, y,y));
-    }
+        bitmap = bitmap.GetSubBitmap(wxRect(0, 0, y, y));
 
     return bitmap;
 }
 
-wxBitmap wxSearchCtrl::RenderCancelBitmap( int x, int y )
+wxBitmap wxSearchCtrl::RenderCancelBitmap(int x, int y)
 {
     wxColour bg = GetBackgroundColour();
     wxColour fg = GetForegroundColour().ChangeLightness(CANCEL_BITMAP_LIGHTNESS);
 
     //===============================================================================
-    // begin drawing code
+    // Begin of drawing code
     //===============================================================================
-    // image stats
+    // Image stats
 
-    // total size 14x14
-    // force 1:1 ratio
-    if ( x > y )
-    {
+    // Total size 14x14
+    // Force a 1:1 ratio
+    if (x > y)
         // x is too big
         x = y;
-    }
     else
-    {
         // y is too big
         y = x;
-    }
 
-    // 14x14 circle
-    // cross line starts (4,4)-(10,10)
-    // drop (13,16)-(19,6)-(16,9)
+    // Circle:     14x14
+    // Cross line: starts, (4,4)-(10,10)
+    // Drop:       (13,16)-(19,6)-(16,9)
 
     int multiplier = GetMultiplier();
-
     int penWidth = multiplier * x / 14;
 
-    wxBitmap bitmap( multiplier*x, multiplier*y );
-    wxMemoryDC mem;
-    mem.SelectObject(bitmap);
+    wxBitmap bitmap(multiplier * x, multiplier * y);
+    wxBufferedDC bufDC(NULL, bitmap);
 
-    // clear background
-    mem.SetBrush( wxBrush(bg) );
-    mem.SetPen( wxPen(bg) );
-    mem.DrawRectangle(0,0,bitmap.GetWidth(),bitmap.GetHeight());
+    // Clear the background
+    bufDC.SetBrush(wxBrush(bg));
+    bufDC.SetPen(wxPen(bg));
+    //bufDC.Clear();
+    bufDC.DrawRectangle(0, 0, bitmap.GetWidth(), bitmap.GetHeight());
 
-    // draw drop glass
-    mem.SetBrush( wxBrush(fg) );
-    mem.SetPen( wxPen(fg) );
-    int radius = multiplier*x/2;
-    mem.DrawCircle(radius,radius,radius);
+    // Draw the circle
+    bufDC.SetBrush(wxBrush(fg));
+    bufDC.SetPen(wxPen(fg));
+    int radius = multiplier * x / 2;
+    bufDC.DrawCircle(radius, radius, radius);
 
-    // draw cross
+    // Draw the cross
     int lineStartBase = 4 * x / 14;
-    int lineLength = x - 2*lineStartBase;
+    int lineLength = x - 2 * lineStartBase;
 
-    mem.SetPen( wxPen(bg) );
-    mem.SetBrush( wxBrush(bg) );
-    int handleCornerShift = penWidth/2;
-    handleCornerShift = wxMax( handleCornerShift, 1 );
+    bufDC.SetPen(wxPen(bg));
+    bufDC.SetBrush(wxBrush(bg));
+    int handleCornerShift = penWidth / 2;
+    handleCornerShift = wxMax(handleCornerShift, 1);
+
     wxPoint handlePolygon[] =
     {
-        wxPoint(-handleCornerShift,+handleCornerShift),
-        wxPoint(+handleCornerShift,-handleCornerShift),
-        wxPoint(multiplier*lineLength+handleCornerShift,multiplier*lineLength-handleCornerShift),
-        wxPoint(multiplier*lineLength-handleCornerShift,multiplier*lineLength+handleCornerShift),
+        wxPoint(-handleCornerShift, +handleCornerShift),
+        wxPoint(+handleCornerShift, -handleCornerShift),
+        wxPoint(multiplier * lineLength + handleCornerShift, multiplier * lineLength - handleCornerShift),
+        wxPoint(multiplier * lineLength - handleCornerShift, multiplier * lineLength + handleCornerShift),
     };
-    mem.DrawPolygon(WXSIZEOF(handlePolygon),handlePolygon,multiplier*lineStartBase,multiplier*lineStartBase);
+    bufDC.DrawPolygon(WXSIZEOF(handlePolygon), handlePolygon, multiplier * lineStartBase, multiplier * lineStartBase);
+
     wxPoint handlePolygon2[] =
     {
-        wxPoint(+handleCornerShift,+handleCornerShift),
-        wxPoint(-handleCornerShift,-handleCornerShift),
-        wxPoint(multiplier*lineLength-handleCornerShift,-multiplier*lineLength-handleCornerShift),
-        wxPoint(multiplier*lineLength+handleCornerShift,-multiplier*lineLength+handleCornerShift),
+        wxPoint(+handleCornerShift, +handleCornerShift),
+        wxPoint(-handleCornerShift, -handleCornerShift),
+        wxPoint(multiplier * lineLength - handleCornerShift, -multiplier * lineLength - handleCornerShift),
+        wxPoint(multiplier * lineLength + handleCornerShift, -multiplier * lineLength + handleCornerShift),
     };
-    mem.DrawPolygon(WXSIZEOF(handlePolygon2),handlePolygon2,multiplier*lineStartBase,multiplier*(x-lineStartBase));
+    bufDC.DrawPolygon(WXSIZEOF(handlePolygon2), handlePolygon2, multiplier * lineStartBase, multiplier * (x - lineStartBase));
+    
+    bufDC.SelectObject(wxNullBitmap);
 
     //===============================================================================
-    // end drawing code
+    // End of drawing code
     //===============================================================================
 
-    if ( multiplier != 1 )
-    {
+    if (multiplier != 1)
         RescaleBitmap(bitmap, wxSize(x, y));
-    }
 
     return bitmap;
 }
 
 void wxSearchCtrl::RecalcBitmaps()
 {
-    if ( !m_text )
-    {
+    if (!m_text)
         return;
-    }
+
     wxSize sizeText = m_text->GetBestSize();
 
-    int bitmapHeight = sizeText.y - FromDIP(4);
+    int bitmapHeight = sizeText.y; //- FromDIP(4);
     int bitmapWidth  = sizeText.y * 20 / 14;
 
-    if ( !m_searchBitmapUser )
+    if (!m_searchBitmapUser)
     {
-        if (
-            !m_searchBitmap.IsOk() ||
+        if (!m_searchBitmap.IsOk() ||
             m_searchBitmap.GetHeight() != bitmapHeight ||
-            m_searchBitmap.GetWidth() != bitmapWidth
-            )
+            m_searchBitmap.GetWidth() != bitmapWidth)
         {
-            m_searchBitmap = RenderSearchBitmap(bitmapWidth,bitmapHeight,false);
-            if ( !HasMenu() )
-            {
+            m_searchBitmap = RenderSearchBitmap(bitmapWidth, bitmapHeight, false);
+
+            if (!HasMenu())
                 m_searchButton->SetBitmapLabel(m_searchBitmap);
-            }
         }
         // else this bitmap was set by user, don't alter
     }
 
 #if wxUSE_MENUS
-    if ( !m_searchMenuBitmapUser )
+    if (!m_searchMenuBitmapUser)
     {
-        if (
-            !m_searchMenuBitmap.IsOk() ||
+        if (!m_searchMenuBitmap.IsOk() ||
             m_searchMenuBitmap.GetHeight() != bitmapHeight ||
-            m_searchMenuBitmap.GetWidth() != bitmapWidth
-            )
+            m_searchMenuBitmap.GetWidth() != bitmapWidth)
         {
-            m_searchMenuBitmap = RenderSearchBitmap(bitmapWidth,bitmapHeight,true);
-            if ( m_menu )
-            {
+            m_searchMenuBitmap = RenderSearchBitmap(bitmapWidth, bitmapHeight, true);
+
+            if (m_menu)
                 m_searchButton->SetBitmapLabel(m_searchMenuBitmap);
-            }
         }
         // else this bitmap was set by user, don't alter
     }
 #endif // wxUSE_MENUS
 
-    if ( m_cancelButton && !m_cancelBitmapUser )
+    if (!m_cancelBitmapUser)
     {
-        if (
-            !m_cancelBitmap.IsOk() ||
+        if (!m_cancelBitmap.IsOk() ||
             m_cancelBitmap.GetHeight() != bitmapHeight ||
-            m_cancelBitmap.GetWidth() != bitmapHeight
-            )
+            m_cancelBitmap.GetWidth() != bitmapWidth)
         {
-            m_cancelBitmap = RenderCancelBitmap(bitmapHeight,bitmapHeight); // square
+            m_cancelBitmap = RenderCancelBitmap(bitmapWidth, bitmapHeight);
             m_cancelButton->SetBitmapLabel(m_cancelBitmap);
         }
         // else this bitmap was set by user, don't alter
     }
 }
 
-void wxSearchCtrl::OnCancelButton( wxCommandEvent& event )
+void wxSearchCtrl::OnCancelButton(wxCommandEvent& event)
 {
     m_text->Clear();
     event.Skip();
 }
 
-void wxSearchCtrl::OnSize( wxSizeEvent& WXUNUSED(event) )
+void wxSearchCtrl::OnSize(wxSizeEvent& WXUNUSED(event))
 {
     LayoutControls();
 }
@@ -1223,10 +1226,10 @@ void wxSearchCtrl::OnSize( wxSizeEvent& WXUNUSED(event) )
 
 void wxSearchCtrl::PopupSearchMenu()
 {
-    if ( m_menu )
+    if (m_menu)
     {
         wxSize size = GetSize();
-        PopupMenu( m_menu, 0, size.y );
+        PopupMenu(m_menu, 0, size.y);
     }
 }
 


### PR DESCRIPTION
The generic wxSearchCtrl drawings are messy and has the followings Bugs:
* The Search button size and position are not calculated correctly.
* The Cancel button size and position are not calculated correctly.
* The Cancel button background is not cleared.
* The background for both Search and Cancel buttons is not cleared when a custom user image with alpha channel is in use.
* There should not be a margin if any of the Search or Cancel buttons is not shown (visible).
* Replace the regular DC with a buffered one (to avoid flickering).
* Many incorrect comments in the code.

This fix do also beautify the entire code by removing unnecessary curly brackets "{" and "}" (except for scope purpose ones) and formats it using proper spacing for readability.